### PR TITLE
Implement a OpIdx type avoiding type confustion

### DIFF
--- a/src/ir/abstract_syntax_tree.rs
+++ b/src/ir/abstract_syntax_tree.rs
@@ -3,7 +3,7 @@ use sleigh_compile::ldef::SleighLanguage;
 use crate::{
     ir::{
         basic_block::{BlockSlot, DestinationKind, NextBlock},
-        expression::InstructionSize,
+        expression::{InstructionSize, OpIdx},
         high_function::CallingConvention,
         type_system::VariableType,
     },
@@ -16,8 +16,6 @@ use super::{
     scope::{Scope, VariableDefinition},
     Address, BasicBlock, Expression, ExpressionOp, VariableSymbol,
 };
-
-type OpIdx = usize;
 
 pub struct AbstractSyntaxTree {
     pub scope: Scope,
@@ -153,10 +151,12 @@ impl AbstractSyntaxTree {
         match hf.calling_convention {
             CallingConvention::Cdecl => {
                 for addr in &hf.memory_read {
-                    if let ExpressionOp::Variable(VariableSymbol::Varnode(r)) = addr.get(0) {
+                    if let ExpressionOp::Variable(VariableSymbol::Varnode(r)) =
+                        addr.get(OpIdx::from_idx(0))
+                    {
                         if r == &mem.lang.sp {
-                            if let ExpressionOp::Value(_) = addr.get(1) {
-                                if let ExpressionOp::Add(_, _, _) = addr.get(2) {
+                            if let ExpressionOp::Value(_) = addr.get(OpIdx::from_idx(1)) {
+                                if let ExpressionOp::Add(_, _, _) = addr.get(OpIdx::from_idx(2)) {
                                     args.push(VariableSymbol::Ram(Box::new(addr.clone()), 4));
                                 }
                             }
@@ -226,7 +226,7 @@ fn define_all_variables(
     scope: &mut Scope,
     sese: SingleEntrySingleExit<BlockSlot>,
     expression: &Expression,
-    pos: usize,
+    pos: OpIdx,
 ) {
     match &expression[pos] {
         ExpressionOp::Dereference(d) => {

--- a/src/ir/high_function.rs
+++ b/src/ir/high_function.rs
@@ -10,7 +10,10 @@ use super::{
     program_tree_structure::ProgramTreeStructure,
     Expression, ExpressionOp, VariableSymbol,
 };
-use crate::{ir::expression::InstructionSize, memory::Memory};
+use crate::{
+    ir::expression::{InstructionSize, OpIdx},
+    memory::Memory,
+};
 
 use super::{Address, BasicBlock};
 
@@ -68,8 +71,11 @@ fn analysis(
         }
         NextBlock::Return => {
             let stack_state = composed_block.registers.get(sp).unwrap();
-            if stack_state.get_entry_point() != 0
-                || !matches!(stack_state.get(0), ExpressionOp::Variable(_))
+            if stack_state.get_entry_point().as_idx() != 0
+                || !matches!(
+                    stack_state.get(OpIdx::from_idx(0)),
+                    ExpressionOp::Variable(_)
+                )
             {
                 println!(
                     "TODO: Function returns at {} Non-initial stack pointer: ESP = {}",

--- a/src/symbol_resolver.rs
+++ b/src/symbol_resolver.rs
@@ -1,62 +1,68 @@
 use std::collections::HashMap;
 
 use crate::ir::{
-    address::Address, 
+    address::Address,
     basic_block::DestinationKind,
-    expression::{Expression, ExpressionOp, VariableSymbol},
+    expression::{Expression, ExpressionOp, OpIdx, VariableSymbol},
     scope::VariableDefinition,
-    type_system::VariableType
+    type_system::VariableType,
 };
 
 pub struct SymbolTable {
-    pub map: HashMap<Address, VariableDefinition>
+    pub map: HashMap<Address, VariableDefinition>,
 }
 
 impl SymbolTable {
     pub fn new() -> Self {
-        Self { map: HashMap::new() }
+        Self {
+            map: HashMap::new(),
+        }
     }
 
-    pub fn add<A:Into<Address>>(&mut self, address:A, size:u8, symbol:String) {
+    pub fn add<A: Into<Address>>(&mut self, address: A, size: u8, symbol: String) {
         let address = address.into();
-        self.map.insert(address, VariableDefinition { 
-            kind: VariableType::default(), 
-            name: symbol, 
-            variable: VariableSymbol::Ram(Box::new(Expression::from(address)), size)});
+        self.map.insert(
+            address,
+            VariableDefinition {
+                kind: VariableType::default(),
+                name: symbol,
+                variable: VariableSymbol::Ram(Box::new(Expression::from(address)), size),
+            },
+        );
     }
 
-    pub fn resolve(&self, e:&VariableSymbol) -> Option<&VariableDefinition> {
+    pub fn resolve(&self, e: &VariableSymbol) -> Option<&VariableDefinition> {
         match e {
-            VariableSymbol::Varnode(_) |
-            VariableSymbol::CallResult{..} => None,
+            VariableSymbol::Varnode(_) | VariableSymbol::CallResult { .. } => None,
             VariableSymbol::Ram(e, _) => self.resolve_exp(e),
         }
     }
 
-    pub fn resolve_mut(&mut self, e:&VariableSymbol) ->Option<&mut VariableDefinition> {
+    pub fn resolve_mut(&mut self, e: &VariableSymbol) -> Option<&mut VariableDefinition> {
         match e {
-            VariableSymbol::Varnode(_) |
-            VariableSymbol::CallResult{..} => None,
+            VariableSymbol::Varnode(_) | VariableSymbol::CallResult { .. } => None,
             VariableSymbol::Ram(e, _) => {
-                get_expresson_value_or_dereference_value(e, e.get_entry_point()).and_then(|addr| self.map.get_mut(&addr))
+                get_expresson_value_or_dereference_value(e, e.get_entry_point())
+                    .and_then(|addr| self.map.get_mut(&addr))
             }
         }
     }
 
-    pub fn resolve_exp(&self, e:&Expression) -> Option<&VariableDefinition> {
-        get_expresson_value_or_dereference_value(e, e.get_entry_point()).and_then(|addr| self.map.get(&addr))
+    pub fn resolve_exp(&self, e: &Expression) -> Option<&VariableDefinition> {
+        get_expresson_value_or_dereference_value(e, e.get_entry_point())
+            .and_then(|addr| self.map.get(&addr))
     }
 
-    pub fn resolve_destination(&self, dst:&DestinationKind) -> Option<&VariableDefinition> {
+    pub fn resolve_destination(&self, dst: &DestinationKind) -> Option<&VariableDefinition> {
         match dst {
             DestinationKind::Symbolic(e) => self.resolve_exp(e),
             DestinationKind::Concrete(address) => self.map.get(&address),
-            DestinationKind::Virtual(_,_) => None,
+            DestinationKind::Virtual(_, _) => None,
         }
     }
 }
 
-fn get_expresson_value_or_dereference_value(e:&Expression, pos:usize) -> Option<Address> {
+fn get_expresson_value_or_dereference_value(e: &Expression, pos: OpIdx) -> Option<Address> {
     match &e[pos] {
         ExpressionOp::Value(v) => Some(Address(*v)),
         ExpressionOp::Dereference(pos) => get_expresson_value_or_dereference_value(e, *pos),

--- a/src/tab_viewer/decompiler.rs
+++ b/src/tab_viewer/decompiler.rs
@@ -1,4 +1,7 @@
-use crate::{ir::basic_block::BlockSlot, VariableSymbol};
+use crate::{
+    ir::{basic_block::BlockSlot, expression::OpIdx},
+    VariableSymbol,
+};
 use std::{borrow::Cow, collections::HashMap};
 
 use egui::{
@@ -445,7 +448,7 @@ impl Decompiler {
         hf: &HighFunction,
         e: &Expression,
         ip_block: SingleEntrySingleExit<BlockSlot>,
-        pos: usize,
+        pos: OpIdx,
     ) {
         match &e[pos] {
             ExpressionOp::Value(v) => {
@@ -596,7 +599,7 @@ impl Decompiler {
         hf: &HighFunction,
         e: &Expression,
         ip_block: SingleEntrySingleExit<BlockSlot>,
-        pos: usize,
+        pos: OpIdx,
         is_call: bool,
     ) {
         match &e[pos] {


### PR DESCRIPTION
TLDR: This PR adds no new functionality, mostly makes the DOCs easier to search. If you think those changes are too noisy, feel free to refuse this PR.

I noticed that the type `OpIdx` was defined twice, in `exrepssion.rs` and `abstract_syntax_tree.rs`, also searching for functions that accept `OpIdx` was very hard. So I decide to change it into a real type.

Besides being much easier to find functions for operating on the tree, it's also much harder to mix up types, as the current code accepts any usize.

Before
<img width="1003" height="146" alt="screen1" src="https://github.com/user-attachments/assets/9bed2abd-0fd6-4c1d-9d38-f2741c7501fe" />
After
<img width="1009" height="369" alt="screen2" src="https://github.com/user-attachments/assets/16e25cd2-ac6a-4ea9-a7ec-46d2639602e7" />
